### PR TITLE
Partially switch from js-beautify to es-beautifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ you may have to copy or modify the extensions rules into your rules
 
 to get the desired beautifying behavior.
 
+If you want to configure html or css beautifying behavior, you'll need to setup a
+.jsbeautifyrc
+
   
   
 

--- a/README.md
+++ b/README.md
@@ -11,13 +11,40 @@ It uses the command-line/node.js javascript formatter from http://jsbeautifier.o
 
 # Requirements
 
-* `js-beautify` installed by typing: `npm -g install js-beautify`
+* `js-beautify` installed by typing: `npm -g install js-beautify --save-dev`
+* `es-beautifier` installed by typing: `npm install es-beautifier eslint eslint-plugin-es-beautifier --save-dev`
 
 # Installation
 
 ## Manual
 
 Just drop `web-beautify.el`. somewhere in your `load-path`.
+
+Then your configure your .eslintrc along the lines of this example:
+https://github.com/dai-shi/es-beautifier#example-1
+Web beautify uses es-beautifier, which after adding the es-beautifier plugin
+to your eslintrc, uses your custom rules to extend it's behavior. 
+So if you have another eslint extenstion e.g. airbnb
+
+  "extends": [
+    "eslint-config-airbnb",
+    "plugin:es-beautifier/standard"
+  ],
+  
+you may have to copy or modify the extensions rules into your rules
+
+  "rules": {
+    "camelcase": 0,
+    "comma-dangle": 0, 
+    "id-length": [1, { "exceptions": ["i","j","k","x","y","z","_"]}],
+    "indent": ["error", 2, { "SwitchCase": 1 }],
+    ....
+
+to get the desired beautifying behavior.
+
+  
+  
+
 
 ```lisp
 (add-to-list 'load-path "~/somewhere")

--- a/web-beautify.el
+++ b/web-beautify.el
@@ -67,15 +67,17 @@
 (defvar web-beautify-css-program "css-beautify"
   "The executable to use for formatting CSS.")
 
-(defvar web-beautify-js-program "js-beautify"
+(defvar web-beautify-js-program "es-beautifier"
   "The executable to use for formatting JavaScript and JSON.")
 
+
 (defconst web-beautify-args '("-f" "-"))
+(defconst es-beautifier-args '("-u"))
 
 (defun web-beautify-command-not-found-message (program)
   "Construct a message about PROGRAM not found."
   (format
-   "%s not found. Install it with `npm -g install js-beautify`."
+   "%s not found. Install it with `npm -g install es-beautifier`."
    program))
 
 (defun web-beautify-format-error-message (buffer-name)
@@ -86,7 +88,10 @@
 
 (defun web-beautify-get-shell-command (program)
   "Join PROGRAM with the constant js-beautify args."
-  (mapconcat 'identity (append (list program) web-beautify-args) " "))
+  (if (eq program web-beautify-js-program)
+      (mapconcat 'identity (append (list program) es-beautifier-args) " ")
+      (mapconcat 'identity (append (list program) web-beautify-args) " "))
+  )
 
 (declare-function web-mode-reload "ext:web-mode")
 (declare-function js2-mode "ext:js2-mode")

--- a/web-beautify.el
+++ b/web-beautify.el
@@ -72,7 +72,7 @@
 
 
 (defconst web-beautify-args '("-f" "-"))
-(defconst es-beautifier-args '("-u"))
+(defconst web-beautify-es-beautifier-args '("-u"))
 
 (defun web-beautify-command-not-found-message (program)
   "Construct a message about PROGRAM not found."

--- a/web-beautify.el
+++ b/web-beautify.el
@@ -89,7 +89,7 @@
 (defun web-beautify-get-shell-command (program)
   "Join PROGRAM with the constant js-beautify args."
   (if (eq program web-beautify-js-program)
-      (mapconcat 'identity (append (list program) es-beautifier-args) " ")
+      (mapconcat 'identity (append (list program) web-beautify-es-beautifier-args) " ")
       (mapconcat 'identity (append (list program) web-beautify-args) " "))
   )
 


### PR DESCRIPTION
es-beautifier allows you to use your .eslintrc rules to determine linting behavior for ecmascript.
It's a trade off, there's more configuration and stuff to install, slightly more customizability and possibly fewer files (though es-beautifier doesn't do html or css beautifying).
If accepted I will also be making some pull requests downstream in spacemacs docs.