### PR TITLE
Fix(web-beautify.el): reload local variables with web-beautify-reload

### DIFF
--- a/web-beautify.el
+++ b/web-beautify.el
@@ -97,7 +97,9 @@
   (cond ((eq major-mode 'web-mode)
          (web-mode-reload))
         ((eq major-mode 'js2-mode)
-         (js2-mode))))
+         (js2-mode)))
+  (let ((enable-local-variables :all))
+    (hack-dir-local-variables-non-file-buffer)))
 
 (defun web-beautify-format-region (program beginning end)
   "By PROGRAM, format each line in the BEGINNING .. END region."


### PR DESCRIPTION
After doing web-beautify-reload, the local variables defined in
".dir-locals.el" will not be applied, so the resetting action is needed.