### PR TITLE
Add generic `web-beautify-buffer` command and example `use-package` setup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+# next
+
+- New features:
+
+   - Added `web-beautify-buffer` command, which runs the major-mode-appropriate
+     buffer beautifier function.
+
 # 0.3.1 (Apr 9, 2016)
 
 - Bug fixes:

--- a/README.md
+++ b/README.md
@@ -34,59 +34,79 @@ you can install `web-beautify.el` from the [MELPA](http://melpa.milkbox.net/) re
 
 Add the following to your emacs init file.
 
-    (require 'web-beautify) ;; Not necessary if using ELPA package
-    (eval-after-load 'js2-mode
-      '(define-key js2-mode-map (kbd "C-c b") 'web-beautify-js))
-    ;; Or if you're using 'js-mode' (a.k.a 'javascript-mode')
-    (eval-after-load 'js
-      '(define-key js-mode-map (kbd "C-c b") 'web-beautify-js))
+### Complete setup using [`use-package`](https://github.com/jwiegley/use-package)
 
-    (eval-after-load 'json-mode
-      '(define-key json-mode-map (kbd "C-c b") 'web-beautify-js))
+``` lisp
+(use-package web-beautify
+  :after (:any js-mode js2-mode json-mode sgml-mode mhtml-mode web-mode css-mode scss-mode)
+  :hook ((js-mode js2-mode json-mode html-mode mhtml-mode web-mode css-mode scss-mode) . web-beautify-before-save-enable)
+  :bind ((:map js-mode-map ("C-c b" . web-beautify-js))
+         (:map js2-mode-map ("C-c b" . web-beautify-js))
+         (:map json-mode-map ("C-c b" . web-beautify-js))
+         (:map html-mode-map ("C-c b" . web-beautify-html))
+         (:map mhtml-mode-map ("C-c b" . web-beautify-html))
+         (:map css-mode-map ("C-c b" . web-beautify-css))
+         (:map scss-mode-map ("C-c b" . web-beautify-css))))
+```
 
-    (eval-after-load 'sgml-mode
-      '(define-key html-mode-map (kbd "C-c b") 'web-beautify-html))
+### Manual setup
 
-    (eval-after-load 'web-mode
-      '(define-key web-mode-map (kbd "C-c b") 'web-beautify-html))
+``` lisp
+(require 'web-beautify) ;; Not necessary if using ELPA package
+(eval-after-load 'js2-mode
+  '(define-key js2-mode-map (kbd "C-c b") 'web-beautify-js))
+;; Or if you're using 'js-mode' (a.k.a 'javascript-mode')
+(eval-after-load 'js
+  '(define-key js-mode-map (kbd "C-c b") 'web-beautify-js))
 
-    (eval-after-load 'css-mode
-      '(define-key css-mode-map (kbd "C-c b") 'web-beautify-css))
+(eval-after-load 'json-mode
+  '(define-key json-mode-map (kbd "C-c b") 'web-beautify-js))
+
+(eval-after-load 'sgml-mode
+  '(define-key html-mode-map (kbd "C-c b") 'web-beautify-html))
+
+(eval-after-load 'web-mode
+  '(define-key web-mode-map (kbd "C-c b") 'web-beautify-html))
+
+(eval-after-load 'css-mode
+  '(define-key css-mode-map (kbd "C-c b") 'web-beautify-css))
+```
 
 If you want to automatically format before saving a file,
 add the following hook to your emacs configuration:
 
-    (eval-after-load 'js2-mode
-      '(add-hook 'js2-mode-hook
-                 (lambda ()
-                   (add-hook 'before-save-hook 'web-beautify-js-buffer t t))))
+``` lisp
+(eval-after-load 'js2-mode
+  '(add-hook 'js2-mode-hook
+             (lambda ()
+               (add-hook 'before-save-hook 'web-beautify-buffer t t))))
 
-    ;; Or if you're using 'js-mode' (a.k.a 'javascript-mode')
-    (eval-after-load 'js
-      '(add-hook 'js-mode-hook
-                 (lambda ()
-                   (add-hook 'before-save-hook 'web-beautify-js-buffer t t))))
+;; Or if you're using 'js-mode' (a.k.a 'javascript-mode')
+(eval-after-load 'js
+  '(add-hook 'js-mode-hook
+             (lambda ()
+               (add-hook 'before-save-hook 'web-beautify-buffer t t))))
 
-    (eval-after-load 'json-mode
-      '(add-hook 'json-mode-hook
-                 (lambda ()
-                   (add-hook 'before-save-hook 'web-beautify-js-buffer t t))))
+(eval-after-load 'json-mode
+  '(add-hook 'json-mode-hook
+             (lambda ()
+               (add-hook 'before-save-hook 'web-beautify-buffer t t))))
 
-    (eval-after-load 'sgml-mode
-      '(add-hook 'html-mode-hook
-                 (lambda ()
-                   (add-hook 'before-save-hook 'web-beautify-html-buffer t t))))
+(eval-after-load 'sgml-mode
+  '(add-hook 'html-mode-hook
+             (lambda ()
+               (add-hook 'before-save-hook 'web-beautify-buffer t t))))
 
-    (eval-after-load 'web-mode
-      '(add-hook 'web-mode-hook
-                 (lambda ()
-                   (add-hook 'before-save-hook 'web-beautify-html-buffer t t))))
+(eval-after-load 'web-mode
+  '(add-hook 'web-mode-hook
+             (lambda ()
+               (add-hook 'before-save-hook 'web-beautify-buffer t t))))
 
-    (eval-after-load 'css-mode
-      '(add-hook 'css-mode-hook
-                 (lambda ()
-                   (add-hook 'before-save-hook 'web-beautify-css-buffer t t))))
-
+(eval-after-load 'css-mode
+  '(add-hook 'css-mode-hook
+             (lambda ()
+               (add-hook 'before-save-hook 'web-beautify-buffer t t))))
+```
 
 ## `js-beautify` settings
 

--- a/test/test-package-install.el
+++ b/test/test-package-install.el
@@ -17,3 +17,5 @@
 (should-autoloadp 'web-beautify-html-buffer)
 (should-autoloadp 'web-beautify-css-buffer)
 (should-autoloadp 'web-beautify-js-buffer)
+(should-autoloadp 'web-beautify-before-save-enable)
+(should-autoloadp 'web-beautify-buffer)

--- a/web-beautify.el
+++ b/web-beautify.el
@@ -23,6 +23,21 @@
 
 ;; Add the following to your Emacs init file.
 
+;; Complete setup using `use-package':
+
+;; (use-package web-beautify
+;;   :after (:any js-mode js2-mode json-mode sgml-mode mhtml-mode web-mode css-mode scss-mode)
+;;   :hook ((js-mode js2-mode json-mode html-mode mhtml-mode web-mode css-mode scss-mode) . web-beautify-before-save-enable)
+;;   :bind ((:map js-mode-map ("C-c b" . web-beautify-js))
+;;          (:map js2-mode-map ("C-c b" . web-beautify-js))
+;;          (:map json-mode-map ("C-c b" . web-beautify-js))
+;;          (:map html-mode-map ("C-c b" . web-beautify-html))
+;;          (:map mhtml-mode-map ("C-c b" . web-beautify-html))
+;;          (:map css-mode-map ("C-c b" . web-beautify-css))
+;;          (:map scss-mode-map ("C-c b" . web-beautify-css))))
+
+;; Manual setup:
+
 ;;     (require 'web-beautify) ;; Not necessary if using ELPA package
 ;;     (eval-after-load 'js2-mode
 ;;       '(define-key js2-mode-map (kbd "C-c b") 'web-beautify-js))
@@ -39,22 +54,22 @@
 ;;     (eval-after-load 'js2-mode
 ;;       '(add-hook 'js2-mode-hook
 ;;                  (lambda ()
-;;                    (add-hook 'before-save-hook 'web-beautify-js-buffer t t))))
+;;                    (add-hook 'before-save-hook 'web-beautify-buffer t t))))
 
 ;;     (eval-after-load 'json-mode
 ;;       '(add-hook 'json-mode-hook
 ;;                  (lambda ()
-;;                    (add-hook 'before-save-hook 'web-beautify-js-buffer t t))))
+;;                    (add-hook 'before-save-hook 'web-beautify-buffer t t))))
 
 ;;     (eval-after-load 'sgml-mode
 ;;       '(add-hook 'html-mode-hook
 ;;                  (lambda ()
-;;                    (add-hook 'before-save-hook 'web-beautify-html-buffer t t))))
+;;                    (add-hook 'before-save-hook 'web-beautify-buffer t t))))
 
 ;;     (eval-after-load 'css-mode
 ;;       '(add-hook 'css-mode-hook
 ;;                  (lambda ()
-;;                    (add-hook 'before-save-hook 'web-beautify-css-buffer t t))))
+;;                    (add-hook 'before-save-hook 'web-beautify-buffer t t))))
 
 ;; For more information, See URL https://github.com/yasuyk/web-beautify.
 

--- a/web-beautify.el
+++ b/web-beautify.el
@@ -70,6 +70,16 @@
 (defvar web-beautify-js-program "js-beautify"
   "The executable to use for formatting JavaScript and JSON.")
 
+(defvar web-beautify-major-mode-alist '((js-mode    . web-beautify-js-buffer)
+                                        (js2-mode   . web-beautify-js-buffer)
+                                        (json-mode  . web-beautify-js-buffer)
+                                        (html-mode  . web-beautify-html-buffer)
+                                        (mhtml-mode . web-beautify-html-buffer)
+                                        (web-mode   . web-beautify-html-buffer)
+                                        (css-mode   . web-beautify-css-buffer)
+                                        (scss-mode  . web-beautify-css-buffer))
+  "An alist of major modes and their associated beautifier function.")
+
 (defconst web-beautify-args '("-f" "-"))
 
 (defun web-beautify-command-not-found-message (program)
@@ -184,6 +194,21 @@ Formatting is done according to the js-beautify command."
   "Format the current buffer according to the js-beautify command."
   (web-beautify-format-buffer web-beautify-js-program))
 
+;;;###autoload
+(defun web-beautify-before-save-enable ()
+  "Enable the buffer-local beautifier in `before-save-hook'."
+  (add-hook 'before-save-hook 'web-beautify-buffer t t))
+
+;;;###autoload
+(defun web-beautify-buffer ()
+  "Call the appropriate beautifier function for the current major-mode.
+The function is determined by `web-beautify-major-mode-alist'. If
+there is no associated entry for the current major-mode, this function
+has no effect."
+  (interactive)
+  (let* ((beautifier (assoc major-mode web-beautify-major-mode-alist)))
+    (when beautifier
+      (funcall (cdr beautifier)))))
 
 (provide 'web-beautify)
 


### PR DESCRIPTION
Thanks for this package, it's working great for me!

This PR adds the `web-beautify-buffer` command, which autodetects which `web-beautify-*-buffer` function it should run, based on the current buffer's major-mode.

I also updated the documentation and added an example `use-package` config, which makes the setup for this package nice and clean IMO. Another nice thing is that `use-package` is smart about autoloading packages for adding hooks or binding commands--no need to manually wrap a bunch of things in `with-eval-after-load`.

I still need to update the docs in a couple places, but I thought I'd put this PR up first to see if this is something you'd be interested in merging.