### PR TITLE
Changed web-beautify-args '("-f" "-") to web-beautify-args '("-"), as of js-beautify 1.8.9

### DIFF
--- a/web-beautify.el
+++ b/web-beautify.el
@@ -70,7 +70,7 @@
 (defvar web-beautify-js-program "js-beautify"
   "The executable to use for formatting JavaScript and JSON.")
 
-(defconst web-beautify-args '("-f" "-"))
+(defconst web-beautify-args '("-"))
 
 (defun web-beautify-command-not-found-message (program)
   "Construct a message about PROGRAM not found."


### PR DESCRIPTION
Changed web-beautify-args '("-f" "-") to web-beautify-args '("-"), otherwise `js-beautify` (v1.8.9) replaces the filename with `-`  (`-f` does not have the formerly desired effect) and results in error, code isn't formatted.